### PR TITLE
Use updated nginx base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.13
+FROM nginx:1.25-alpine
 
 # Install openssh-server to provide web ssh access from kudu, supervisor to run processor
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- use up-to-date nginx base image `1.25-alpine`

## Testing
- `docker build -t azure-appservice-nginx:test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fd33e1c48325b5350ce766f9b87c